### PR TITLE
About page ternary 2nd expression issue

### DIFF
--- a/templates/_layout/main.twig
+++ b/templates/_layout/main.twig
@@ -37,7 +37,7 @@
           <div class="site-footer__nav-item">
             <nav class="nav">
               <ul class="nav__list">
-                <li class="site-footer__item"><a href="{{ lang ? '/' ~ lang : '' }}about">{{ about }}</a></li>
+                <li class="site-footer__item"><a href="{{ lang ? '/' ~ lang : '/about' }}">{{ about }}</a></li>
                 <li class="site-footer__item"><a href="https://blog.tokenbrowser.com/">{{ blog }}</a></li>
                 <li class="site-footer__item"><a href="https://developers.tokenbrowser.com/">{{ developers }}</a></li>
               </ul>


### PR DESCRIPTION

![screen shot 2017-04-20 at 11 39 28 am](https://cloud.githubusercontent.com/assets/2993032/25245226/fa24065c-25c0-11e7-8a89-b7c8d0820deb.png)
Template would always append 'about', and second expression in ternary is empty string. worked fine on root level of domain, but any other pages it would be /pagename/about (eg when you are on the about page, the footer directs you to https://www.tokenbrowser.com/about/about).